### PR TITLE
オートログイン（RemenberMe）機能を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,5 @@ Metrics/BlockLength:
     - "config/routes.rb"
     - "config/environments/development.rb"
     - "config/environments/production.rb"
+    - "spec/system/user_sessions/login_sessions_spec.rb"
+    - "spec/system/user_sessions/logout_sessions_spec.rb"

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -3,6 +3,7 @@
 # パスワードリセット用コントローラー
 class PasswordResetsController < ApplicationController
   skip_before_action :require_login
+  skip_before_action :auto_login_with_remember_me
 
   def new; end
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -3,6 +3,7 @@
 # ユーザーのログインに関するコントローラーです。
 class UserSessionsController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  skip_before_action :auto_login_with_remember_me, only: %i[new create]
 
   def new
     @user = User.new
@@ -11,17 +12,47 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      flash[:success] = 'ログインしました'
-      redirect_to root_path
+      handle_successful_login
     else
-      flash.now[:danger] = 'ログインに失敗しました'
-      render :new, status: :unprocessable_entity
+      handle_failed_login
     end
   end
 
   def destroy
+    clear_session # クッキーがあれば削除処理を実行
+
     logout
     flash[:danger] = 'ログアウトしました'
     redirect_to login_path, status: :see_other
+  end
+
+  private
+
+  def handle_successful_login
+    ip_address = request.remote_ip
+    session_retention(ip_address) if params[:remember_me] == '1'
+
+    flash[:success] = 'ログインしました'
+    redirect_to root_path
+  end
+
+  def handle_failed_login
+    flash.now[:danger] = 'ログインに失敗しました'
+    render :new, status: :unprocessable_entity
+  end
+
+  def session_retention(ip_address)
+    session_data = Session.create_session_for(@user, ip_address)
+    cookies.permanent.signed[:session_id] = session_data[:session].id
+    cookies.permanent[:remember_token] = session_data[:token]
+  end
+
+  def clear_session
+    if (session_id = cookies.signed[:session_id])
+      session = Session.find_by(id: session_id)
+      session&.destroy
+      cookies.delete(:session_id)
+      cookies.delete(:remember_token)
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@
 # ユーザーの新規登録に関するコントローラーです。
 class UsersController < ApplicationController
   skip_before_action :require_login
+  skip_before_action :auto_login_with_remember_me
 
   def new
     @user = User.new

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,6 +1,44 @@
 # frozen_string_literal: true
 
-# ユーザーのログインに関するモデルです。
+# ユーザーのログイン情報に関するモデルです。オートログインのメソッドが設定されています。
 class Session < ApplicationRecord
   belongs_to :user
+
+  # バリデーション
+  validates :user_id, presence: true
+  validates :remember_digest, presence: true
+  validates :login_time, presence: true
+  validates :expires_at, presence: true
+  validates :ip_address, presence: true, format: { with: /\A\d{1,3}(\.\d{1,3}){3}\z/, message: 'は有効なIPアドレスではありません' }
+
+  # トークン生成用メソッド
+  def self.generate_token
+    SecureRandom.urlsafe_base64
+  end
+
+  # セッションを作成する
+  def self.create_session_for(user, ip_address)
+    token = generate_token
+    digest = BCrypt::Password.create(token)
+    session = create(
+      user: user,
+      remember_digest: digest,
+      login_time: Time.current,
+      expires_at: 2.weeks.from_now,
+      ip_address: ip_address
+    )
+    { session: session, token: token }
+  end
+
+  # トークン認証
+  def valid_token?(token)
+    return false if remember_digest.nil?
+
+    BCrypt::Password.new(remember_digest).is_password?(token)
+  end
+
+  # セッションの有効期限を確認
+  def expired?
+    Time.current > expires_at
+  end
 end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -14,9 +14,14 @@
               <%= form.email_field :email, class: 'form-control', id: 'email', placeholder: 'メールアドレスを入力' %>
             </div>
             
-            <div class="mb-4">
+            <div class="mb-2">
               <%= form.label :password, 'パスワード', class: 'form-label' %>
               <%= form.password_field :password, class: 'form-control', id: 'password', placeholder: 'パスワードを入力' %>
+            </div>
+
+            <div class="form-check mb-4">
+              <%= form.check_box :remember_me, class: 'form-check-input', id: 'remember_me' %>
+              <%= form.label :remember_me, 'ログイン状態を保持する', class: 'form-check-label' %>
             </div>
             
             <div class="mb-3">

--- a/db/migrate/20241128023443_update_sessions_table_for_remember_me.rb
+++ b/db/migrate/20241128023443_update_sessions_table_for_remember_me.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# sessionsテーブルにオートログインのためのカラムを追加
+class UpdateSessionsTableForRememberMe < ActiveRecord::Migration[7.0]
+  def up
+    change_table :sessions, bulk: true do |t|
+      t.string :remember_digest, after: :user_id
+      t.datetime :expires_at, after: :login_time
+      t.remove :activity_type
+    end
+  end
+
+  def down
+    change_table :sessions, bulk: true do |t|
+      t.remove :remember_digest
+      t.remove :expires_at
+      t.string :activity_type, after: :expires_at # 元の位置に戻す
+    end
+  end
+end

--- a/db/migrate/20241128105706_add_null_constraints_to_sessions.rb
+++ b/db/migrate/20241128105706_add_null_constraints_to_sessions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Sessionsテーブルのカラムにfalseを追加
+class AddNullConstraintsToSessions < ActiveRecord::Migration[7.0]
+  def change
+    change_table :sessions, bulk: true do |t|
+      t.change_null :user_id, false
+      t.change_null :remember_digest, false
+      t.change_null :login_time, false
+      t.change_null :expires_at, false
+      t.change_null :ip_address, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_27_002649) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_28_105706) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -89,10 +89,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_27_002649) do
   end
 
   create_table "sessions", charset: "utf8mb3", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "activity_type"
-    t.datetime "login_time"
-    t.string "ip_address"
+    t.bigint "user_id", null: false
+    t.string "remember_digest", null: false
+    t.datetime "login_time", null: false
+    t.datetime "expires_at", null: false
+    t.string "ip_address", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_sessions_on_user_id"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.include SystemHelpers, type: :system
+  config.include CapybaraCookieHelper, type: :system
 end
 
 RSpec.configure do |config|

--- a/spec/support/capybara_cookie_helper.rb
+++ b/spec/support/capybara_cookie_helper.rb
@@ -1,15 +1,5 @@
 # frozen_string_literal: true
 
-module SystemHelpers
-  def login_as(user)
-    visit login_path
-    fill_in 'email', with: user.email
-    fill_in 'password', with: '12345678'
-    click_button 'ログイン'
-    expect(page).to have_current_path(root_path) # ログイン確認
-  end
-end
-
 module CapybaraCookieHelper
   def get_rack_cookie(cookie_name)
     browser = page.driver.browser

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -9,12 +9,3 @@ module SystemHelpers
     expect(page).to have_current_path(root_path) # ログイン確認
   end
 end
-
-module CapybaraCookieHelper
-  def get_rack_cookie(cookie_name)
-    browser = page.driver.browser
-    browser.manage.all_cookies.find { |c| c[:name] == cookie_name }&.fetch(:value, nil)
-  rescue Selenium::WebDriver::Error::NoSuchCookieError
-    nil
-  end
-end

--- a/spec/system/user_sessions/expires_sessions_spec.rb
+++ b/spec/system/user_sessions/expires_sessions_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'オートログイン', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'セッション切れ' do
+    it '有効期限が切れるとログアウトされる' do
+      # セッションを作成し、有効期限を過去に設定
+      session_data = Session.create_session_for(user, '127.0.0.1')
+      session = session_data[:session]
+      session.update!(expires_at: 1.hour.ago)
+
+      visit root_path
+
+      # セッション切れのためログインページにリダイレクト
+      expect(current_path).to eq(login_path)
+      expect(page).to have_content('ログインしてください。')
+    end
+  end
+end

--- a/spec/system/user_sessions/login_sessions_spec.rb
+++ b/spec/system/user_sessions/login_sessions_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'オートログイン', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'ログイン機能' do
+    it 'Remember Meをチェックした場合、セッションとクッキーが正しく設定される' do
+      visit login_path
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: '12345678'
+      check 'ログイン状態を保持する'
+      click_button 'ログイン'
+      expect(page).to have_current_path(root_path) # ログイン確認
+
+      # ログイン成功後、sessionsテーブルにレコードが作成される
+      session = Session.find_by(user_id: user.id)
+      expect(session).to be_present
+
+      # クッキーにsession_idとremember_tokenが設定されている
+      expect(get_rack_cookie('session_id')).to be_present
+      expect(get_rack_cookie('remember_token')).to be_present
+    end
+
+    it 'Remember Meをチェックしない場合、セッションとクッキーが設定されない' do
+      visit login_path
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: '12345678'
+      uncheck 'ログイン状態を保持する'
+      click_button 'ログイン'
+      expect(page).to have_current_path(root_path) # ログイン確認
+
+      # ログイン成功後、sessionsテーブルにレコードが作成されない
+      session = Session.find_by(user_id: user.id)
+      expect(session).to be_nil
+
+      # クッキーが設定されていない
+      expect(get_rack_cookie('session_id')).to be_nil
+      expect(get_rack_cookie('remember_token')).to be_nil
+    end
+  end
+end

--- a/spec/system/user_sessions/logout_sessions_spec.rb
+++ b/spec/system/user_sessions/logout_sessions_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'オートログイン', type: :system do
+  let(:user) { create(:user) }
+
+  describe 'ログアウト機能' do
+    before do
+      visit login_path
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: '12345678'
+      check 'ログイン状態を保持する'
+      click_button 'ログイン'
+      expect(page).to have_current_path(root_path) # ログイン確認
+    end
+
+    it 'クッキーとセッションが削除される' do
+      click_link 'ログアウト'
+      expect(page).to have_current_path(login_path)
+
+      # sessionsテーブルの該当レコードが削除される
+      session = Session.find_by(user_id: user.id)
+      expect(session).to be_nil
+
+      # クッキーが削除されている
+      expect(get_rack_cookie('session_id')).to be_nil
+      expect(get_rack_cookie('remember_token')).to be_nil
+    end
+
+    it 'クッキーが存在しない場合でも例外を発生させない' do
+      session = Session.find_by(user_id: user.id)
+      session&.destroy
+
+      expect(page).to have_current_path(root_path) # ログイン確認
+      click_link 'ログアウト'
+      # 例外が発生せずにログアウトページにリダイレクトされる
+      expect(page).to have_current_path(login_path)
+      expect(page).to have_content('ログアウトしました')
+    end
+  end
+end


### PR DESCRIPTION
### DB
- テーブルカラムの用意
### ログイン・ログアウト処理
- ログインページにオートログインのチェックボックス設置
- コントローラーのログイン処理にセッションをクッキーに保存する処理を追加
- モデルにトークンの作成・保存・認証メソッド作成
- ApplicationControllerにRemember Me のクッキーがあればセッションを回復するbefore_action追加
- テストコード（systemのみ）

テーブルがUsersではなかったことと、セキュリティのためサブモジュールは不使用としました。